### PR TITLE
fix: SSR

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "express": "4.16.2",
     "history": "^4.7.2",
+    "lodash": "^4.17.10",
     "prop-types": "15.6.0",
     "react": "16.2.0",
     "react-dom": "16.2.0",

--- a/src/app/Home.js
+++ b/src/app/Home.js
@@ -1,24 +1,34 @@
+import isEmpty from 'lodash/isEmpty';
 import React, { Component } from 'react';
 import { Search } from './index';
 import { connect } from 'react-redux';
 
 class Home extends Component {
   render() {
-    console.warn(this.props);
+    const { staticContext, resultsState } = this.props;
+
+    const finalResultsState =
+      staticContext && staticContext.resultsState
+        ? staticContext.resultsState
+        : resultsState;
+
     return (
       <div>
         welcome home
-        <Search/>
+        <Search
+          resultsState={!isEmpty(finalResultsState) ? finalResultsState : null}
+        />
       </div>
-    )
+    );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
-    routing: state.routing
-  } 
-}
+    routing: state.routing,
+    resultsState: state.resultsState,
+  };
+};
 
 export default connect(mapStateToProps)(Home);
 // export default Home;

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -1,21 +1,22 @@
 import { applyMiddleware, createStore, combineReducers } from 'redux';
-import { routerMiddleware, routerReducer} from 'react-router-redux';
+import { routerMiddleware, routerReducer } from 'react-router-redux';
 import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
-import reducer from './reducer';
+import { start, resultsState } from './reducer';
 
 export default function configureStore(history, initialState) {
   const middleware = routerMiddleware(history);
 
   const reducer = combineReducers({
-    start: reducer,
-    router: routerReducer
+    router: routerReducer,
+    resultsState,
+    start,
   });
 
   let enhancer;
 
   enhancer = composeWithDevTools(applyMiddleware(...middleware));
 
-  const store = createStore(reducer, {...initialState}, enhancer);
+  const store = createStore(reducer, { ...initialState }, enhancer);
 
   return store;
 }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,13 +1,12 @@
-const initialState = {
-  start: 'home page',
-}
-
-const reducer = (state = initialState, action) => {
+const initialStartState = { start: 'home page' };
+export const start = (state = initialStartState, action) => {
   switch (action.type) {
-
-  default:
-    return state
+    default:
+      return state;
   }
-}
+};
 
-export default reducer;
+const initialResultsState = {};
+export const resultsState = (state = initialResultsState) => {
+  return state;
+};

--- a/src/server.js
+++ b/src/server.js
@@ -3,9 +3,8 @@ import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { findResultsState } from './app';
 import Main from './app/Main';
-import Home from './app/Home';
 import template from './template';
-import { matchPath, StaticRouter} from 'react-router-dom';
+import { matchPath, StaticRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import configureStore from './configureStore';
 import routes from './routes';
@@ -15,23 +14,34 @@ const server = express();
 server.use('/assets', express.static('assets'));
 
 server.get('*', async (req, res) => {
-  const initialState = { start: 'start from here'};
-  const resultsState = await findResultsState(Home);
+  const initialStore = configureStore(null, {});
+  const resultsState = await findResultsState(() => (
+    <Provider store={initialStore}>
+      <StaticRouter location={req.url} context={{}}>
+        <Main />
+      </StaticRouter>
+    </Provider>
+  ));
+
+  const initialState = { start: 'start from here', resultsState };
+  const context = { resultsState };
   const store = configureStore(null, initialState);
-  const context = {};
-  const appString = renderToString(
+  const body = renderToString(
     <Provider store={store}>
       <StaticRouter location={req.url} context={context}>
-        <Main/>
+        <Main />
       </StaticRouter>
     </Provider>
   );
 
   res.send(
     template({
-      body: appString,
       title: 'Hello World from the server',
-      initialState: JSON.stringify(initialState),
+      initialState: JSON.stringify({
+        ...initialState,
+        resultsState,
+      }),
+      body,
     })
   );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3226,7 +3226,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.17.5:
+lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
I've updated the example, the main issue came from the fact that the `<Home>` component was rendered outside of `<Provider>`. Since it's a connected component it's required to be execute in the scope of a `<Provider>` (or pass the store as props). Now instead of always render the `<Home>` component we use the `StaticRouter` to only render the correct part of the application.

When we retrieve the `resultsState` we need to expose it to the `<Search>` component. On the server we use the React Router [`context`](https://reacttraining.com/react-router/web/guides/server-rendering/adding-app-specific-context-information). On the client we use Redux to restore the `resultsState` on the first mount.

Note: the SSR only work "correctly" works for `/home` & `/about`. For `/search` it's required to update the `<Search>` component to also handle the `staticContext` like we already do in the `<Home>` component.